### PR TITLE
Update .gitignore to include package-lock.json and .env files

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+package-lock.json
+package.json

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env
+package-lock.json
+package.json


### PR DESCRIPTION
Enhance the .gitignore file by adding entries for package-lock.json and .env files to prevent them from being tracked in the repository.