### PR TITLE
Arreglo a las Contraseñas

### DIFF
--- a/backend/src/entity/estudiante.entity.js
+++ b/backend/src/entity/estudiante.entity.js
@@ -27,10 +27,10 @@ const EstudianteSchema = new EntitySchema({
             type: "varchar", 
             length: 100, 
             nullable: false },
-        /*password: { 
+        password: { 
             type: "varchar", 
             length: 255, 
-            nullable: false },*/
+            nullable: false },
         createdAt: {
             type: "timestamp with time zone",
             default: () => "CURRENT_TIMESTAMP",

--- a/backend/src/validations/estudiante.validation.js
+++ b/backend/src/validations/estudiante.validation.js
@@ -33,12 +33,17 @@ export const estudianteSchema = Joi.object({
             "any.required": "La carrera es obligatoria."
         }),
     password: Joi.string()
-        .min(8).max(50).required()
+        .min(8)
+        .max(26)
+        .pattern(/^[a-zA-Z0-9]+$/)
+        .required()
         .messages({
-            "string.empty": "La contraseña no puede estar vacía.",
-            "string.min": "La contraseña debe tener al menos 8 caracteres.",
-            "string.max": "La contraseña debe tener máximo 50 caracteres.",
-            "any.required": "La contraseña es obligatoria."
+          "string.empty": "La contraseña no puede estar vacía.",
+          "any.required": "La contraseña es obligatorio.",
+          "string.base": "La contraseña debe ser de tipo texto.",
+          "string.min": "La contraseña debe tener al menos 8 caracteres.",
+          "string.max": "La contraseña debe tener como máximo 26 caracteres.",
+          "string.pattern.base": "La contraseña solo puede contener letras y números.",
         }),
     telefono: Joi.string()
         .pattern(/^[0-9+]{9,20}$/)


### PR DESCRIPTION
This pull request introduces changes to the `EstudianteSchema` entity and its validation rules to enhance password handling. The most notable updates include re-enabling the `password` field in the entity schema and refining the password validation constraints.

### Entity Schema Updates:
* [`backend/src/entity/estudiante.entity.js`](diffhunk://#diff-44f281ac902c8cb25587c2eb7b1c30d19851cffc51ea8744bc5ab7dc1865ae19L30-R33): Re-enabled the `password` field in the `EstudianteSchema` with a `varchar` type, a maximum length of 255, and a `nullable: false` constraint.

### Validation Rule Updates:
* `backend/src/validations/estudiante.validation.js`: Updated the password validation rules in `estudianteSchema` to:
  - Restrict the password length to a minimum of 8 and a maximum of 26 characters.
  - Add a regex pattern to ensure the password only contains alphanumeric characters.
  - Provide additional error messages for invalid input, including type, length, and pattern violations.Se descomento las contraseñas del esquema de estudiante, ahora las contraseñas se guardan en la base de datos